### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ directory. See the per-module guides for exact commands:
 - [pre-reg-113-115/AGENTS.md](pre-reg-113-115/AGENTS.md)
 
 Neither module has a `src/test` directory in this repository — there are no
-automated unit or integration tests to run. Do not assume `mvn test` will
-exercise any project-specific logic; it only runs whatever tests ship
-transitively with dependencies (none, currently).
+automated unit or integration tests to run. `mvn test` will complete without
+executing any project tests; it does not run tests packaged in transitive
+dependencies.
 
 ## Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,164 @@
+# AGENTS.md
+
+## Repository Overview
+
+`migration-utility` is a small collection of standalone, one-off tools used
+during MOSIP version upgrades to migrate or re-encrypt data that lives in
+Postgres databases (and, in one case, MinIO/S3 object stores). It is not a
+long-running MOSIP service — each tool here is run manually or as a
+short-lived job during a specific upgrade window, then normally left idle.
+
+The repo has two independent Java/Spring Boot modules plus two standalone SQL
+scripts, each covering a different upgrade path:
+
+| Path | Purpose | Guide |
+|------|---------|-------|
+| [`pms-115-120/`](pms-115-120/AGENTS.md) | Migrates/publishes Partner Management Service (PMS) data to IDA via websub, for the 1.1.5 → 1.2.0.1 upgrade | [pms-115-120/AGENTS.md](pms-115-120/AGENTS.md) |
+| [`pre-reg-113-115/`](pre-reg-113-115/AGENTS.md) | Re-encrypts pre-registration demographic/document data when the encryption key changed from `REGISTRATION` to `PRE_REGISTRATION` (1.1.3 → 1.1.5/1.2.0.1) | [pre-reg-113-115/AGENTS.md](pre-reg-113-115/AGENTS.md) |
+| `db_scripts/ArchivalScript.sql` | Standalone SQL script that moves pre-registration records into `*_CONSUMED` tables | Documented below and in [pre-reg-113-115/AGENTS.md](pre-reg-113-115/AGENTS.md) (it is the companion script for that module) |
+
+There is no shared parent build (no root `pom.xml`) — the two Java modules
+build and release independently, each with their own Maven project and
+Dockerfile.
+
+## Technology Stack
+
+- Java 21, Spring Boot 3.2.3, Maven
+- PostgreSQL (JDBC/Hibernate) as the data source for both Java modules
+- MinIO/S3-compatible object storage (`pre-reg-113-115` only)
+- MOSIP kernel libraries (`kernel-core`, `kernel-dataaccess-hibernate`,
+  `kernel-websubclient-api`, `khazana`) pulled from MOSIP's Maven
+  repositories, plus Spring Cloud Config for externalized configuration
+- Docker (`eclipse-temurin:21-jre-alpine` base images) for packaging
+- GitHub Actions (reusable workflows hosted in `mosip/kattu`) for CI
+
+## Build & Test Commands
+
+There is no root-level build — build each module from inside its own
+directory. See the per-module guides for exact commands:
+
+- [pms-115-120/AGENTS.md](pms-115-120/AGENTS.md)
+- [pre-reg-113-115/AGENTS.md](pre-reg-113-115/AGENTS.md)
+
+Neither module has a `src/test` directory in this repository — there are no
+automated unit or integration tests to run. Do not assume `mvn test` will
+exercise any project-specific logic; it only runs whatever tests ship
+transitively with dependencies (none, currently).
+
+## Configuration
+
+Both modules use Spring Cloud Config plus local `application*.properties`
+files that are already checked into the repo with **example/dev
+credentials** (e.g. `mosip.pms.secretKey=abc123`,
+`javax.persistence.jdbc.password=mosip123`,
+`object.store.s3.secretkey=minioadmin`). These are placeholder values for the
+MOSIP dev/QA sandbox, not real secrets — but treat them as such: never
+replace them with real production credentials in a committed file. Real
+deployments override these via Spring Cloud Config (see
+`spring.cloud.config.uri` / `spring.cloud.config.label`) or environment
+variables passed at Docker runtime.
+
+See each module's guide for the specific properties files involved.
+
+## Project Structure Notes
+
+```text
+migration-utility/
+├── db_scripts/ArchivalScript.sql       # standalone SQL, pre-reg archival
+├── pms-115-120/                        # PMS -> IDA migration utility (Java)
+│   ├── utility/                        # the actual Maven project
+│   └── db_scripts/                     # SQL run against the PMS DB
+├── pre-reg-113-115/                    # pre-reg re-encryption utility (Java)
+└── .github/workflows/                  # CI (build, release, tag)
+```
+
+Note the asymmetry: for `pms-115-120` the Maven project lives one level down,
+in `pms-115-120/utility/`; for `pre-reg-113-115` the Maven project is at the
+top of that directory. This is reflected in the CI `SERVICE_LOCATION` values
+(see below) and in each module's own guide.
+
+## Development Workflow
+
+1. Pick the module you're changing and read its `AGENTS.md` first — the two
+   modules are unrelated in code (different Java packages, no shared
+   dependency between them) and target different MOSIP upgrade paths.
+2. Make changes inside that module's directory only; do not introduce
+   cross-module dependencies.
+3. Build the module locally with Maven (see the module guide) before
+   committing — there is no CI step you can run locally that substitutes for
+   this, since both modules use MOSIP-internal `kernel-*` artifacts that only
+   resolve against MOSIP's Nexus/Maven repositories.
+4. If you touch SQL under `db_scripts/`, treat it as production-impacting:
+   review it manually against a non-production database first. See the
+   Repository-Specific Considerations section below.
+
+## Pull Request Guidelines
+
+- CI (`.github/workflows/push-trigger.yml`) runs on `pull_request` events of
+  type `opened`, `reopened`, `synchronize`, and builds **both** modules
+  independently via reusable workflows in `mosip/kattu`
+  (`build-maven-migration-utility` for `pms-115-120/utility`,
+  `build-maven-pre-reg-113-115` for `pre-reg-113-115`), followed by Docker
+  image builds for each. A PR that only touches one module still triggers
+  builds for both, so check the Actions output for the module you actually
+  changed.
+- Keep commits scoped to one module where possible, since the two utilities
+  are released and versioned independently.
+- Update the relevant module's `README.md` if you change setup steps,
+  properties, or deployment instructions — this `AGENTS.md` tree summarizes
+  behavior but the READMEs are still the canonical operator-facing docs.
+
+## Repository-Specific Considerations
+
+- **This repo runs destructive SQL against real MOSIP databases.** Both
+  `db_scripts/ArchivalScript.sql` and `pms-115-120/db_scripts/migration-scripts.sql`
+  are meant to be hand-run by an operator during a planned upgrade window,
+  not executed automatically. `ArchivalScript.sql` `DELETE`s rows from
+  `prereg.applicant_demographic`, `prereg.applicant_document`, and
+  `prereg.reg_appointment` after copying them into `*_consumed`/`CONSUMED`
+  tables — see the Do-not rules below and in
+  [pre-reg-113-115/AGENTS.md](pre-reg-113-115/AGENTS.md).
+- Both Java modules disable Hibernate's own datasource/entity-manager
+  autoconfiguration (`DataSourceAutoConfiguration`,
+  `DataSourceTransactionManagerAutoConfiguration`,
+  `HibernateJpaAutoConfiguration` are excluded in each `Application` /
+  `ReEncryptUtilityApplication` class) and wire persistence manually — do not
+  "fix" this by re-enabling autoconfiguration without checking why it was
+  excluded.
+- Each module's Docker image renames its jar to a fixed name inside the
+  image (`Utility-0.0.1-SNAPSHOT.jar` for `pms-115-120`,
+  `ReEncryptUtility.jar` for `pre-reg-113-115`) regardless of the Maven
+  version in `pom.xml`. Don't assume the jar filename mentioned in a README
+  matches the version in `pom.xml`.
+
+## Agent rules
+
+### Do
+
+1. Read the relevant module's `AGENTS.md` and `README.md` before editing
+   anything in it.
+2. Keep changes to one module per PR/commit where practical.
+3. Treat every SQL script under `db_scripts/` as something that runs once,
+   by hand, against a real environment — review it as carefully as
+   production-impacting code, even though it isn't wired into any pipeline.
+4. Verify Maven builds locally from inside the correct module directory
+   before assuming CI will catch problems.
+5. Preserve the `-D` system-property-before-`-jar` ordering in any Java
+   command example you write or edit (e.g.
+   `java -Dloader.path=... -jar app.jar`), matching the existing Dockerfiles.
+
+### Do not
+
+1. Do not run `ArchivalScript.sql` or `migration-scripts.sql` against a
+   database you are not certain is disposable/non-production — they
+   permanently delete or move rows.
+2. Do not commit real credentials into any `application*.properties` file;
+   the existing dev/QA values in this repo are illustrative only.
+3. Do not merge the two modules' dependencies or source trees together —
+   they are independently versioned and released.
+4. Do not assume there are tests to run — there is no `src/test` in either
+   module today. Do not report "tests pass" or "tests added" unless you
+   actually added a test directory and ran it.
+5. Do not add a nested `AGENTS.md` for `db_scripts/` folders — they are
+   single-file, hand-run SQL with no build/run process of their own; the
+   parent module guide (or this file) is the right place to document them.

--- a/pms-115-120/AGENTS.md
+++ b/pms-115-120/AGENTS.md
@@ -60,19 +60,25 @@ invocation pattern used in deployment — note system properties (`-D...`)
 come before `-jar`:
 
 ```shell
-java -jar -Dloader.path="$loader_path_env" \
+java -Dloader.path="$loader_path_env" \
   -Dspring.cloud.config.label="$spring_config_label_env" \
   -Dspring.cloud.config.name="$spring_config_name_env" \
   -Dspring.profiles.active="$active_profile_env" \
   -Dspring.cloud.config.uri="$spring_config_url_env" \
-  Utility-0.0.1-SNAPSHOT.jar
+  -jar Utility-0.0.1-SNAPSHOT.jar
 ```
 
-(That example is copied verbatim from the shipped Dockerfile, including the
-unconventional `-D` flags after `-jar` — Spring Boot's own launcher still
-accepts them there because it re-parses `-D` args itself, but do not copy
-that pattern into new, non-Spring-Boot Java commands: for a plain `java`
-invocation, `-D` flags must precede `-jar` to be recognized by the JVM.)
+**The shipped `pms-115-120/utility/Dockerfile`'s `CMD` actually places
+these same `-D` flags after `-jar`, not before.** That is not a
+Spring-Boot-specific convenience — the JVM launcher stops parsing `-D`
+options once it hits `-jar`, so everything after that point (including
+`-Dloader.path=...`, the Spring Cloud Config properties, etc.) is passed
+to the app as plain positional arguments, not as system properties. This
+looks like a real, pre-existing bug in the Dockerfile that may mean the
+container silently runs without the intended Spring Cloud Config/loader
+settings applied — flag this if asked to review that Dockerfile, and
+always write new `java -jar` examples with `-D` flags before `-jar`,
+matching the corrected order above rather than the shipped file.
 
 Properties needed by this utility are documented upstream in
 [`pms-migration-utility-default.properties`](https://github.com/mosip/mosip-config/blob/develop-v3/pms-migration-utility-default.properties).

--- a/pms-115-120/AGENTS.md
+++ b/pms-115-120/AGENTS.md
@@ -1,0 +1,133 @@
+# AGENTS.md
+
+[Back to repo root](../AGENTS.md)
+
+## Purpose
+
+Migrates and publishes Partner Management Service (PMS) data — approved
+API keys, MISP licenses, partner records, policies — from PMS to IDA over
+websub, as part of the MOSIP 1.1.5.5 → 1.2.0.1-B1 upgrade. It can run once as
+a migration, or be scheduled as a cronjob (via Kubernetes) to keep publishing
+data changes at intervals.
+
+## Layout
+
+```text
+pms-115-120/
+├── README.md                                             # operator-facing setup/run doc
+├── Steps_to_deploy_pms-migration-utility_in_v2_deployment.pdf
+├── db_scripts/
+│   ├── README.md
+│   └── migration-scripts.sql       # creates pms.last_sync_time_stamp for cronjob mode
+└── utility/                        # <-- the actual Maven project lives here, not at pms-115-120/
+    ├── pom.xml                     # artifactId "Utility", groupId io.mosip.pms
+    ├── Dockerfile
+    ├── .gitignore
+    └── src/main/
+        ├── java/io/mosip/pms/ida/
+        │   ├── Application.java            # Spring Boot entry point (CommandLineRunner)
+        │   ├── constant/                   # EventType, PmsConstant
+        │   ├── dao/                        # JPA entities + repositories (Partner, AuthPolicy, MISPLicenseEntity, ...)
+        │   ├── dto/                        # request/response/event DTOs
+        │   ├── service/PMSDataMigrationService.java  # core migration logic, invoked from Application.run()
+        │   ├── util/                       # CertUtil, MapperUtils, RestUtil, UtilityLogger
+        │   └── websub/WebSubPublisher.java # publishes migrated events to the websub hub
+        └── resources/
+            ├── bootstrap.properties        # spring.cloud.config.* wiring, server.port=8081
+            └── application-dev.properties  # dev-profile DB/auth/websub settings (placeholder creds)
+```
+
+There is no `src/test` directory in this module.
+
+## How to run
+
+Build and run locally, from inside `utility/`:
+
+```shell
+cd utility
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true
+java -jar target/Utility-0.0.1-SNAPSHOT.jar
+```
+
+Build a Docker image:
+
+```console
+docker build -t name:tag -f Dockerfile .
+```
+
+The Dockerfile's `CMD` (see `utility/Dockerfile`) shows the actual runtime
+invocation pattern used in deployment — note system properties (`-D...`)
+come before `-jar`:
+
+```shell
+java -jar -Dloader.path="$loader_path_env" \
+  -Dspring.cloud.config.label="$spring_config_label_env" \
+  -Dspring.cloud.config.name="$spring_config_name_env" \
+  -Dspring.profiles.active="$active_profile_env" \
+  -Dspring.cloud.config.uri="$spring_config_url_env" \
+  Utility-0.0.1-SNAPSHOT.jar
+```
+
+(That example is copied verbatim from the shipped Dockerfile, including the
+unconventional `-D` flags after `-jar` — Spring Boot's own launcher still
+accepts them there because it re-parses `-D` args itself, but do not copy
+that pattern into new, non-Spring-Boot Java commands: for a plain `java`
+invocation, `-D` flags must precede `-jar` to be recognized by the JVM.)
+
+Properties needed by this utility are documented upstream in
+[`pms-migration-utility-default.properties`](https://github.com/mosip/mosip-config/blob/develop-v3/pms-migration-utility-default.properties).
+Local defaults (dev profile) live in
+`utility/src/main/resources/application-dev.properties` and already contain
+placeholder dev credentials (`secretKey=abc123`,
+`javax.persistence.jdbc.password=mosip123`) — do not replace these with real
+credentials in a commit.
+
+### Before running, per `README.md`
+
+1. Add the roles listed in the repo `README.md` to Keycloak for the
+   `mosip-partner-client` (PUBLISH_*) and `mosip-ida-client` (SUBSCRIBE_*)
+   clients.
+2. Run the seed SQL in `README.md` against the PMS database (creates a
+   default policy group/partner/policy so the migration has something to
+   publish).
+3. For cronjob mode, set
+   `mosip.pms.utility.run.mode=cronjob` and run
+   `db_scripts/migration-scripts.sql` against `mosip_pms` first — it creates
+   the `pms.last_sync_time_stamp` table the cronjob uses to track its last
+   run.
+
+## CI
+
+`.github/workflows/push-trigger.yml` builds this module via
+`SERVICE_LOCATION: pms-115-120/utility` (job
+`build-maven-migration-utility`), then builds and pushes a Docker image as
+`pms-migration-utility` (job `build-dockers`). Both run on pushes to
+`master`, `1.*`, `develop*`, `MOSIP*`, `release*`, and on pull requests.
+
+## Agent rules
+
+### Do
+
+1. Run all Maven/Docker commands from inside `utility/`, not from
+   `pms-115-120/` — that's where `pom.xml` and `Dockerfile` actually live.
+2. Keep `-D` system properties before `-jar` in any new plain `java`
+   command you write (the shipped Dockerfile's ordering is Spring
+   Boot-specific and should not be imitated outside a Spring Boot fat jar).
+3. If you change what `db_scripts/migration-scripts.sql` creates, update
+   `db_scripts/README.md` in the same change — they describe the same
+   script.
+4. Treat `application-dev.properties` values as placeholders only.
+
+### Do not
+
+1. Do not run `db_scripts/migration-scripts.sql` against a production
+   `mosip_pms`/`mosip_authdevice`/`mosip_regdevice` database without a
+   verified backup — it creates a new table and (per its own header) is part
+   of a live-database schema change during an upgrade window.
+2. Do not remove the `@EnableAutoConfiguration(exclude = {...})` line in
+   `Application.java` without understanding why datasource/JPA
+   autoconfiguration is disabled — this module wires persistence manually.
+3. Do not add real secrets/passwords to `application-dev.properties` or any
+   other file under `src/main/resources/`.
+4. Do not assume a `src/test` directory exists — there isn't one; don't
+   report tests as added/passing unless you created and ran them yourself.

--- a/pre-reg-113-115/AGENTS.md
+++ b/pre-reg-113-115/AGENTS.md
@@ -51,11 +51,17 @@ The jar name follows Spring Boot's default `artifactId-version` pattern from
 `pom.xml` (`ReEncryptUtility-1.2.1-SNAPSHOT.jar`); confirm the exact filename
 in `target/` after a build, since `pom.xml` version bumps change it.
 
-Or use the published Docker image, per `README.md`:
+Or use the published Docker image. `README.md` documents this as `docker
+pull mosipdev/pre-reg-113-115:develop` followed by
+`docker run re-encrypt-utility` — that second command runs a different,
+undefined image reference (`re-encrypt-utility:latest`) rather than the
+one just pulled, so following the README literally fails unless that tag
+already happens to exist locally. Run the image that was actually
+pulled instead:
 
 ```shell
 docker pull mosipdev/pre-reg-113-115:develop
-docker run re-encrypt-utility
+docker run --rm mosipdev/pre-reg-113-115:develop
 ```
 
 Building the image locally:
@@ -105,7 +111,8 @@ To run it:
    PGHOST="your-host"
    PGUSER="your-username"
    PGDATABASE="your-database"
-   psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -f ArchivalScript.sql
+   psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" \
+     -f ../db_scripts/ArchivalScript.sql   # run from pre-reg-113-115/; this file lives at the repo root, not here
    ```
 
 This script is destructive and irreversible outside of a database backup —

--- a/pre-reg-113-115/AGENTS.md
+++ b/pre-reg-113-115/AGENTS.md
@@ -1,0 +1,145 @@
+# AGENTS.md
+
+[Back to repo root](../AGENTS.md)
+
+## Purpose
+
+Re-encrypts MOSIP pre-registration demographic and document data when the
+encryption key name changed from `REGISTRATION` (MOSIP 1.1.3) to
+`PRE_REGISTRATION` (MOSIP 1.1.5+). Used during the 1.1.3 → 1.1.5 upgrade, and
+still applicable for a 1.1.5 → 1.2.0.1 upgrade even if 1.1.5 still uses the
+old key name. It supports two scenarios: re-encrypting across two separate
+environments (different key sets), or re-encrypting in place after an
+in-environment application upgrade (same key set).
+
+The companion SQL script for this module — `../db_scripts/ArchivalScript.sql`
+— lives one level up, at the repo root, not inside this directory.
+
+## Layout
+
+```text
+pre-reg-113-115/
+├── README.md              # scenarios, prerequisites, docker run steps, properties reference
+├── Dockerfile
+├── pom.xml                # artifactId "ReEncryptUtility", groupId com.ReEncryptUtility
+├── mvnw / mvnw.cmd
+├── .gitignore
+└── src/main/
+    ├── java/com/reencryptutility/
+    │   ├── ReEncryptUtilityApplication.java   # Spring Boot entry point (CommandLineRunner)
+    │   ├── dto/                               # CryptoManagerRequestDTO/ResponseDTO, RequestWrapper, ResponseWrapper
+    │   ├── entity/                            # DemographicEntity, DocumentEntity
+    │   ├── repository/                        # DemographicRepository, DocumentRepository
+    │   └── service/
+    │       ├── ReEncrypt.java                 # core re-encryption logic, invoked from Application.run()
+    │       ├── Database.java, DatabaseRouter.java, DatabaseThreadContext.java, RoutingDataSource.java
+    └── resources/application.properties       # primary/secondary datasource, object store, crypto settings
+```
+
+There is no `src/test` directory in this module.
+
+## How to run
+
+Build locally with the wrapper (Maven not required on PATH):
+
+```shell
+./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip=true
+java -jar target/ReEncryptUtility-1.2.1-SNAPSHOT.jar
+```
+
+The jar name follows Spring Boot's default `artifactId-version` pattern from
+`pom.xml` (`ReEncryptUtility-1.2.1-SNAPSHOT.jar`); confirm the exact filename
+in `target/` after a build, since `pom.xml` version bumps change it.
+
+Or use the published Docker image, per `README.md`:
+
+```shell
+docker pull mosipdev/pre-reg-113-115:develop
+docker run re-encrypt-utility
+```
+
+Building the image locally:
+
+```console
+docker build -t name:tag -f Dockerfile .
+```
+
+### Configuration (`src/main/resources/application.properties`)
+
+The checked-in file already contains **placeholder dev/QA values**
+(`datasource.primary.password=kamesh`, `secretKey=abc123`,
+`object.store.s3.secretkey=minioadmin`) — do not replace them with real
+credentials in a commit. Before a real run, set (per `README.md`):
+
+- `isNewDatabase=true` for the two-environment scenario, `false` for the
+  same-environment scenario.
+- `datasource.primary.*` (source DB) and, for the two-environment scenario,
+  `datasource.secondary.*` (destination DB).
+- `object.store.s3.*` (source MinIO/S3) and, for the two-environment
+  scenario, `destinationObjectStore.s3.*` (destination).
+- `mosip.base.url`, `decryptBaseUrl`, `encryptBaseUrl`,
+  `decryptAppId`/`decryptReferenceId`, `encryptAppId`/`encryptReferenceId`.
+
+### Prerequisites (per `README.md`)
+
+1. Properties from the upstream
+   [`pre-reg-113-115-application-default.properties`](https://github.com/mosip/mosip-config/blob/develop1-v3/pre-reg-113-115-application-default.properties).
+2. A running kernel Config Server.
+3. A running Key Manager service.
+4. `mosip_prereg` database and MinIO reachable in both source and
+   destination environments.
+
+## Archival script (`db_scripts/ArchivalScript.sql`, repo root)
+
+Moves `prereg.applicant_demographic`, `prereg.applicant_document`, and
+`prereg.reg_appointment` rows whose `cr_dtimes`/`upd_dtimes` fall in a
+`startDate`/`endDate` window into the corresponding `*_consumed` /
+`CONSUMED` tables, **then deletes the moved rows from the source tables**.
+To run it:
+
+1. Edit the `startDate`/`endDate` literals inside the script (they are
+   hardcoded `DECLARE` values at the top of the `DO $$ ... END $$;` block).
+2. Execute it directly against the target Postgres database:
+
+   ```shell
+   PGHOST="your-host"
+   PGUSER="your-username"
+   PGDATABASE="your-database"
+   psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -f ArchivalScript.sql
+   ```
+
+This script is destructive and irreversible outside of a database backup —
+see the Do-not rules below.
+
+## CI
+
+`.github/workflows/push-trigger.yml` builds this module via
+`SERVICE_LOCATION: pre-reg-113-115` (job `build-maven-pre-reg-113-115`), then
+builds and pushes a Docker image as `pre-reg-113-115` (job
+`build-dockers-pre-reg-113-115`). Both run on pushes to `master`, `1.*`,
+`develop*`, `MOSIP*`, `release*`, and on pull requests.
+
+## Agent rules
+
+### Do
+
+1. Use `./mvnw` (the wrapper committed in this directory) rather than
+   assuming a system Maven install.
+2. Keep `application.properties` placeholder-only; document required keys
+   in `README.md`/this file instead of hardcoding real endpoints.
+3. When editing `ReEncrypt.java` or the routing datasource classes, keep the
+   primary/secondary datasource split intact — `isNewDatabase` controls
+   whether the secondary datasource is used at all.
+
+### Do not
+
+1. Do not run `../db_scripts/ArchivalScript.sql` against any database
+   without first confirming `startDate`/`endDate` and having a verified
+   backup — it permanently deletes rows from `prereg.applicant_demographic`,
+   `prereg.applicant_document`, and `prereg.reg_appointment` after copying
+   them to `*_consumed`/`CONSUMED` tables.
+2. Do not run this utility's re-encryption flow against a production
+   `mosip_prereg` database without dry-running it against a non-production
+   copy first — a decrypt/re-encrypt pass touches every migrated record.
+3. Do not commit real credentials into `application.properties`.
+4. Do not assume a `src/test` directory exists — there isn't one.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds an AGENTS.md tree (root hub + per-module guides for pms-115-120 and pre-reg-113-115) covering repository overview, tech stack, build/run commands, configuration, and explicit Do/Do-not rules for AI coding assistants and contributors, including warnings about the destructive SQL migration/archival scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide guidance for MOSIP migration utilities.
  * Documented module structure, setup, configuration, local and Docker execution, and CI workflows.
  * Added module-specific guidance for PMS migration and pre-registration re-encryption utilities.
  * Clarified database prerequisites, migration and archival operations, credential handling, backups, and safety considerations.
  * Added development, pull request, and agent workflow guidance for migration modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->